### PR TITLE
Add support for passing options as arguments

### DIFF
--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -186,7 +186,7 @@ class Interactions:
 
         :param command: The command that the callback is registered for
         :param callback: The function that is called when the command is triggered
-        :return: The name of the command
+        :return: An object containing all the command data (e.g. structure, callbacks)
         """
 
         if isinstance(command, str):

--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -36,16 +36,23 @@ from discord_interactions import (
     ApplicationClient,
 )
 from discord_interactions import ocm
-from typing import Callable, Union, Type, Dict, List, Tuple, Optional
+from typing import Callable, Union, Type, Dict, List, Tuple, Optional, Any
 
-from .context import AfterCommandContext
+from .context import AfterCommandContext, CommandContext
 
 
-_CommandCallback = Callable[
-    [Union[Interaction, ocm.Command]],
-    Union[InteractionResponse, str, None, Tuple[Optional[str], bool]],
+_CommandCallbackReturnType = Union[
+    InteractionResponse, str, None, Tuple[Optional[str], bool]
+]
+_CommandCallback = Union[
+    Callable[
+        [Union[Interaction, ocm.Command]],
+        _CommandCallbackReturnType,
+    ],
+    Callable[[CommandContext, Any], _CommandCallbackReturnType],
 ]
 _AfterCommandCallback = Callable[[AfterCommandContext], None]
+_DecoratedCommand = Union[ApplicationCommand, str, _CommandCallback, Type[ocm.Command]]
 
 
 class CommandData:
@@ -119,13 +126,33 @@ class Interactions:
             cmd = interaction.data.name
             cb = self._commands[cmd].callback
 
-            cb_data = interaction
-            if len(annotations := cb.__annotations__.values()) > 0:
-                cmd_type = next(iter(annotations))
-                if issubclass(cmd_type, ocm.Command):
-                    cb_data = cmd_type.wrap(interaction)
+            if cb.__code__.co_argcount > 1:  # if the cb takes more than one argument
+                ctx = CommandContext(interaction, self._app_id)
+                arg_diff = cb.__code__.co_argcount - (len(interaction.data.options) + 1)
+                num_kwargs = len(cb.__defaults__)
+                if arg_diff > 1 or (arg_diff > 0 and num_kwargs > 1):
+                    # if more than one argument is not provided
+                    cb_args = interaction.data.options[:-arg_diff]
+                    cb_kwargs = interaction.data.options[-arg_diff:]
+                    print(cb_args, cb_kwargs, num_kwargs, arg_diff)
+                else:
+                    cb_args = interaction.data.options
+                    cb_kwargs = []
+                resp = cb(
+                    ctx,
+                    *[o.value for o in cb_args],
+                    **{o.name: o.value for o in cb_kwargs},
+                )
+            else:
+                cb_data = interaction
+                if len(annotations := cb.__annotations__.values()) > 0:
+                    cmd_type = next(iter(annotations))
+                    if issubclass(cmd_type, ocm.Command):
+                        cb_data = cmd_type.wrap(interaction)
+                    elif issubclass(cmd_type, CommandContext):
+                        cb_data = cmd_type(interaction, self._app_id)
 
-            resp = cb(cb_data)
+                resp = cb(cb_data)
 
             if isinstance(resp, InteractionResponse):
                 interaction_response = resp
@@ -207,7 +234,7 @@ class Interactions:
         return cmd
 
     def command(
-        self, command: Union[ApplicationCommand, str, _CommandCallback] = None
+        self, command: _DecoratedCommand = None
     ) -> Union[Callable[[_CommandCallback], CommandData], CommandData]:
         """
         A decorator to register a slash command.
@@ -217,7 +244,7 @@ class Interactions:
         """
 
         _f = None
-        if isinstance(command, Callable):
+        if isinstance(command, Callable) and not isinstance(command, type(ocm.Command)):
             _f = command
             command = None
 

--- a/examples/flask_webhook.py
+++ b/examples/flask_webhook.py
@@ -1,4 +1,8 @@
-from discord_interactions.flask_ext import Interactions, AfterCommandContext
+from discord_interactions.flask_ext import (
+    Interactions,
+    AfterCommandContext,
+    CommandContext,
+)
 from discord_interactions import (
     ApplicationCommand,
     ApplicationCommandOption,
@@ -42,6 +46,29 @@ rps_cmd = ApplicationCommand(
     ],
 )
 
+guess_cmd = ApplicationCommand(
+    "guess",
+    "Guess my number!",
+    [
+        ApplicationCommandOption(
+            type=ApplicationCommandOptionType.INTEGER,
+            name="number",
+            description="what do you guess?",
+            required=True,
+        ),
+        ApplicationCommandOption(
+            type=ApplicationCommandOptionType.INTEGER,
+            name="min_num",
+            description="smallest possible number (default: 0)",
+        ),
+        ApplicationCommandOption(
+            type=ApplicationCommandOptionType.INTEGER,
+            name="max_num",
+            description="biggest possible number (default: 10)",
+        ),
+    ],
+)
+
 
 # Note that only a name is provided here,
 # so for this command only the callback gets registered.
@@ -82,6 +109,26 @@ def rps(interaction: Interaction):
             msg = "You cut me and win!"
 
     return f"I took {choice}. {msg}"
+
+
+# When you are annotating the first parameter as type 'CommandContext' OR
+# when the function takes more than one parameter,
+# the command options will be directly passed to the function as arguments,
+# the context object being the first argument.
+# Note: The keyword parameter names must match the option names!
+@interactions.command(guess_cmd)
+def guess(ctx: CommandContext, guessed_num, min_num=None, max_num=None):
+    min_val = min_num or 0  # defaults to 0
+    max_val = max_num or 10  # defaults to 10
+
+    my_number = random.randint(min_val, max_val)
+
+    if my_number == guessed_num:
+        msg = "You are correct! :tada:"
+    else:
+        msg = "You guessed it wrong. :confused:"
+
+    return f"My number was {my_number}. {msg}"
 
 
 @interactions.command("delay")

--- a/examples/flask_webhook_ocm.py
+++ b/examples/flask_webhook_ocm.py
@@ -1,4 +1,4 @@
-from discord_interactions.flask_ext import Interactions
+from discord_interactions.flask_ext import Interactions, CommandContext
 from discord_interactions.ocm import Command, Option, OptionChoices
 from flask import Flask
 import os
@@ -28,6 +28,14 @@ class RPS(Command):
     """ Play Rock, Paper, Scissors! """
 
     symbol: RPSSymbol = Option("rock, paper or scissors", required=True)
+
+
+class Guess(Command):
+    """ Guess my number! """
+
+    number: int = Option("what do you guess?", required=True)
+    min_num: int = Option("smallest possible number (default: 0)")
+    max_num: int = Option("biggest possible number (default: 10)")
 
 
 @interactions.command
@@ -63,6 +71,23 @@ def rps(cmd: RPS):
             msg = "You cut me and win!"
 
     return f"I took {choice.value}. {msg}"
+
+
+# This type of syntax does also work with the OCM, though, it will lose the advantage
+# of the command class being used as container for the interaction data.
+@interactions.command(Guess)
+def guess(ctx: CommandContext, guessed_num, min_num=None, max_num=None):
+    min_val = min_num or 0  # defaults to 0
+    max_val = max_num or 10  # defaults to 10
+
+    my_number = random.randint(min_val, max_val)
+
+    if my_number == guessed_num:
+        msg = "You are correct! :tada:"
+    else:
+        msg = "You guessed it wrong. :confused:"
+
+    return f"My number was {my_number}. {msg}"
 
 
 if __name__ == "__main__":

--- a/tests/test_flask_webhook.py
+++ b/tests/test_flask_webhook.py
@@ -47,6 +47,22 @@ test_data = [
             },
         },
     ),
+    (
+        {
+            "id": "44444",
+            "name": "guess",
+            "options": [
+                {"name": "number", "value": 42},
+                {"name": "max_num", "value": 69},
+            ],
+        },
+        {
+            "type": InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
+            "data": {
+                "content": DO_NOT_VALIDATE,
+            },
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
Command options can now be passed to the callback functions as arguments in combination with a `CommandContext` object