### PR TITLE
Fix a few things and increase patch version

### DIFF
--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -135,11 +135,10 @@ class Interactions:
                 ctx = CommandContext(interaction, self._app_id)
                 arg_diff = cb.__code__.co_argcount - (len(interaction.data.options) + 1)
                 num_kwargs = len(cb.__defaults__)
-                if arg_diff > 1 or (arg_diff > 0 and num_kwargs > 1):
-                    # if more than one argument is not provided
+                if 1 < num_kwargs > arg_diff > 0:
+                    # if not all arguments can be passed by position
                     cb_args = interaction.data.options[:-arg_diff]
                     cb_kwargs = interaction.data.options[-arg_diff:]
-                    print(cb_args, cb_kwargs, num_kwargs, arg_diff)
                 else:
                     cb_args = interaction.data.options
                     cb_kwargs = []

--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -94,7 +94,11 @@ class Interactions:
     def commands(self) -> List[ApplicationCommand]:
         """ All registered application commands """
 
-        return [cmd.application_command for cmd in self._commands.values()]
+        return [
+            cmd.application_command
+            for cmd in self._commands.values()
+            if cmd.application_command is not None
+        ]
 
     def create_commands(self, client: ApplicationClient, guild: int = None):
         """ Create all registered commands as application commands at Discord. """

--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -37,6 +37,7 @@ from discord_interactions import (
 )
 from discord_interactions import ocm
 from typing import Callable, Union, Type, Dict, List, Tuple, Optional, Any
+from threading import Thread
 
 from .context import AfterCommandContext, CommandContext
 
@@ -203,7 +204,9 @@ class Interactions:
             return response
 
         ctx = AfterCommandContext(interaction, interaction_response, self._app_id)
-        cmd.after_callback(ctx)
+
+        t = Thread(target=cmd.after_callback, args=(ctx,))
+        t.start()
 
         return response
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r", encoding="utf-8") as f:
 
 setup(
     name="discord-interactions.py",
-    version="0.0.4",
+    version="0.0.5",
     description="A library around the Discord Interactions API",
     long_description=readme,
     long_description_content_type="text/x-rst",

--- a/tests/test_flask_webhook.py
+++ b/tests/test_flask_webhook.py
@@ -63,6 +63,21 @@ test_data = [
             },
         },
     ),
+    (
+        {
+            "id": "44444",
+            "name": "guess",
+            "options": [
+                {"name": "number", "value": 7},
+            ],
+        },
+        {
+            "type": InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE.value,
+            "data": {
+                "content": DO_NOT_VALIDATE,
+            },
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
 ### Fixes
 * command property returned `None` for commands that were registered without structural information
 * the `after_command` callbacks now run in a thread, so that the initial response gets returned instantly
 * in some cases the automatic argument passing would try to pass keyword arguments to positional parameters
 
### Further
 * increase patch version to v0.0.5