### PR TITLE
fix: after_request only on interactions endpoint

### DIFF
--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -84,7 +84,7 @@ class Interactions:
         self._path = path
 
         app.add_url_rule(path, "interactions", self._main, methods=["POST"])
-        app.after_request_funcs = {None: [self._after_request]}
+        app.after_request_funcs["interactions"] = self._after_request
 
         self._commands: Dict[str, CommandData] = {}
 


### PR DESCRIPTION
In `flask_ext`, attaching `Interactions` to a new Flask app binds `_after_request` to be fired after any request to the provided Flask app. This poses an issue for users attempting to handle other Flask requests on their own endpoints. In these cases, when another endpoint is called instead of the "interactions" endpoint, `g.interaction` is never defined and causes an exception to be thrown during `_after_request`. This can be resolved by only firing `_after_request` after a request to the "interactions" endpoint.