### PR TITLE
Utilities and improvements

### DIFF
--- a/discord_interactions/__init__.py
+++ b/discord_interactions/__init__.py
@@ -13,6 +13,7 @@ from .interaction_response import (
     ResponseFlags,
     InteractionApplicationCommandCallbackData,
     FollowupMessage,
+    Response,
 )
 
 from .application_command import (

--- a/discord_interactions/__init__.py
+++ b/discord_interactions/__init__.py
@@ -5,6 +5,7 @@ from .interaction import (
     InteractionType,
     ApplicationCommandInteractionData,
     ApplicationCommandInteractionDataOption,
+    ApplicationCommandInteractionDataResolved,
 )
 
 from .interaction_response import (

--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -300,13 +300,13 @@ class Interactions:
                     r_data = None
                     if ephemeral:
                         r_data = InteractionApplicationCommandCallbackData(
-                            flags=[ResponseFlags.EPHEMERAL]
+                            flags=ResponseFlags.EPHEMERAL
                         )
                 else:
                     r_type = InteractionResponseType.CHANNEL_MESSAGE
                     r_data = InteractionApplicationCommandCallbackData(str(resp))
                     if ephemeral:
-                        r_data.flags = [ResponseFlags.EPHEMERAL]
+                        r_data.flags = ResponseFlags.EPHEMERAL
 
                 interaction_response = InteractionResponse(
                     type=r_type,

--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -213,7 +213,7 @@ class Interactions:
         self._path = path
 
         app.add_url_rule(path, "interactions", self._main, methods=["POST"])
-        app.after_request_funcs[None].append(self._after_request)
+        app.after_request_funcs.setdefault(None, []).append(self._after_request)
 
         self._commands: Dict[str, CommandData] = {}
         self._components: Dict[str, ComponentData] = {}

--- a/discord_interactions/flask_ext/interactions.py
+++ b/discord_interactions/flask_ext/interactions.py
@@ -178,7 +178,7 @@ class Interactions:
         self._path = path
 
         app.add_url_rule(path, "interactions", self._main, methods=["POST"])
-        app.after_request_funcs["interactions"] = self._after_request
+        app.after_request_funcs[None].append(self._after_request)
 
         self._commands: Dict[str, CommandData] = {}
 
@@ -385,8 +385,11 @@ class Interactions:
         return resp
 
     def _after_request(self, response: Response):
-        interaction = g.interaction
-        interaction_response = g.interaction_response
+        try:
+            interaction = g.interaction
+            interaction_response = g.interaction_response
+        except AttributeError:
+            return response
 
         if interaction is None:
             return response

--- a/discord_interactions/interaction.py
+++ b/discord_interactions/interaction.py
@@ -123,7 +123,7 @@ class Interaction:
         self.guild_id = int(kwargs.get("guild_id", 0)) or None
         self.channel_id = int(kwargs.get("channel_id", 0)) or None
         self.member = Member(**kwargs["member"]) if "member" in kwargs else None
-        self.user = User(**kwargs["user"]) if "user" in kwargs else None
+        self.user = User(**kwargs["user"]) if "user" in kwargs else self.member.user
         self.token = kwargs["token"]
         self.version = int(kwargs["version"])
 
@@ -146,6 +146,10 @@ class Interaction:
     @property
     def author(self) -> Union[Member, User]:
         return self.member or self.user
+
+    @property
+    def is_dm(self) -> bool:
+        return self.member is None
 
     def get_user(self, user_id: int) -> Optional[User]:
         return self.data.resolved.users.get(user_id)

--- a/discord_interactions/interaction_response.py
+++ b/discord_interactions/interaction_response.py
@@ -134,7 +134,7 @@ class Response(InteractionResponse):
             kwargs["flags"] |= ResponseFlags.EPHEMERAL
 
         super().__init__(
-            type=InteractionResponseType.CHANNEL_MESSAGE,
+            type=InteractionCallbackType.CHANNEL_MESSAGE,
             data=InteractionApplicationCommandCallbackData(
                 content=content, embeds=[embed] if embed else [], **kwargs
             ),

--- a/discord_interactions/interaction_response.py
+++ b/discord_interactions/interaction_response.py
@@ -24,8 +24,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from enum import Enum
-from typing import List, Protocol
+from enum import Enum, Flag
+from typing import List, Protocol, Optional
 from dataclasses import dataclass
 
 
@@ -46,7 +46,8 @@ class InteractionResponseType(Enum):
     DEFERRED_CHANNEL_MESSAGE = 5
 
 
-class ResponseFlags(Enum):
+class ResponseFlags(Flag):
+    NONE = 0
     EPHEMERAL = 64
 
 
@@ -60,11 +61,7 @@ class InteractionApplicationCommandCallbackData:
     tts: bool = False
     embeds: List[DictConvertible] = None
     allowed_mentions: DictConvertible = None
-    flags: List[ResponseFlags] = None
-
-    @staticmethod
-    def _flags_to_int(flags: List[ResponseFlags]) -> int:
-        return sum(map(lambda flag: flag.value, flags))
+    flags: ResponseFlags = ResponseFlags.NONE
 
     def to_dict(self) -> dict:
         data = {}
@@ -78,7 +75,7 @@ class InteractionApplicationCommandCallbackData:
         if self.allowed_mentions:
             data["allowed_mentions"] = self.allowed_mentions.to_dict()
         if self.flags:
-            data["flags"] = self._flags_to_int(self.flags)
+            data["flags"] = self.flags.value
 
         return data
 
@@ -99,6 +96,43 @@ class InteractionResponse:
             response["data"] = self.data.to_dict()
 
         return response
+
+
+class Response(InteractionResponse):
+    """
+    An utility class to create simplified interaction responses to application commands.
+    Useful for responding with an embed.
+
+    Creates an :class:`InteractionResponse` of type
+    `InteractionResponseType.CHANNEL_MESSAGE` internally.
+
+    :type content: Optional[str]
+    :param content: The response message content
+
+    :type embed: Optional[:class:`DictConvertible`] (e.g. discord.py's `discord.Embed`)
+    :param embed: The response message embed
+
+    :type ephemeral: bool
+    :param ephemeral: Whether or not the response should be ephemeral (default: `False`)
+    """
+
+    def __init__(
+        self,
+        content: Optional[str] = None,
+        embed: Optional[DictConvertible] = None,
+        ephemeral: bool = False,
+        **kwargs
+    ):
+        flags = kwargs.setdefault("flags", ResponseFlags.NONE)
+        if ephemeral:
+            flags |= ResponseFlags.EPHEMERAL
+
+        super().__init__(
+            type=InteractionResponseType.CHANNEL_MESSAGE,
+            data=InteractionApplicationCommandCallbackData(
+                content=content, embeds=[embed] if embed else [], flags=flags, **kwargs
+            ),
+        )
 
 
 @dataclass()

--- a/discord_interactions/interaction_response.py
+++ b/discord_interactions/interaction_response.py
@@ -123,14 +123,14 @@ class Response(InteractionResponse):
         ephemeral: bool = False,
         **kwargs
     ):
-        flags = kwargs.setdefault("flags", ResponseFlags.NONE)
+        kwargs.setdefault("flags", ResponseFlags.NONE)
         if ephemeral:
-            flags |= ResponseFlags.EPHEMERAL
+            kwargs["flags"] |= ResponseFlags.EPHEMERAL
 
         super().__init__(
             type=InteractionResponseType.CHANNEL_MESSAGE,
             data=InteractionApplicationCommandCallbackData(
-                content=content, embeds=[embed] if embed else [], flags=flags, **kwargs
+                content=content, embeds=[embed] if embed else [], **kwargs
             ),
         )
 

--- a/discord_interactions/models.py
+++ b/discord_interactions/models.py
@@ -25,7 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from typing import List
+from typing import List, Optional
 from datetime import datetime
 from enum import Enum
 
@@ -73,6 +73,16 @@ class User:
             self.premium_type = PremiumType(premium_type)
 
         self.public_flags = self._parse_flags(int(data.get("public_flags", 0)))
+
+    def __int__(self) -> int:
+        return self.id
+
+    def __str__(self) -> str:
+        return f"{self.username}#{self.discriminator}"
+
+    @property
+    def mention(self) -> str:
+        return f"<@{self.id}>"
 
     @staticmethod
     def _parse_flags(flags: int) -> List[UserFlags]:
@@ -131,9 +141,20 @@ class Member:
         self.mute = data.get("mute")
         self.pending = data.get("pending", False)
 
+    def __str__(self) -> str:
+        return self.display_name or ""
+
     @property
-    def id(self):
+    def id(self) -> Optional[int]:
         return self.user.id if self.user else None
+
+    @property
+    def username(self) -> Optional[str]:
+        return self.user.username if self.user else None
+
+    @property
+    def display_name(self) -> Optional[str]:
+        return self.nick or self.username
 
     def to_dict(self) -> dict:
         data = {


### PR DESCRIPTION
 - add `Response` utility class for avoiding more complex `InteractionResponse` when returning custom response (e.g. useful for returning a message with an embed) (87c1663)
 - change `ResponseFlags` to inherit from `enum.Flags` instead of `enum.Enum` (87c1663)
 - for `ocm.Option`s of type `User`, `Channel` or `Role`, use resolved interaction data to return an instance of the appropriate class (instead of just the ID). This also means that the returned value now actually corresponds to the used annotation and IDEs won't show a warning anymore. (3e59357)
 - improve the way `User`s and `Member`s are handled (855ad07)